### PR TITLE
use docker image from OBS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM yastdevel/ruby
-
+FROM registry.opensuse.org/yast/head/containers/yast-ruby:latest
 COPY . /usr/src/app
 # a workaround to allow package building on a non-s390 machine
 RUN sed -i "/^ExclusiveArch:/d" package/*.spec


### PR DESCRIPTION
For https://trello.com/c/sVVOXYbx/878-5-build-the-docker-images-for-travis-in-obs.
