### PR TITLE
Install by Default if yast2-s390 is Installed

### DIFF
--- a/package/yast2-cio.changes
+++ b/package/yast2-cio.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Mar 30 14:21:39 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Install by default if yast2-s390 is installed (bsc#1158036)
+- 4.2.2
+
+-------------------------------------------------------------------
 Thu Aug 22 16:06:58 CEST 2019 - schubi@suse.de
 
 - Using rb_default_ruby_abi tag in the spec file in order to

--- a/package/yast2-cio.spec
+++ b/package/yast2-cio.spec
@@ -46,6 +46,8 @@ Requires:       yast2 >= 3.0.5
 Requires:       yast2-ruby-bindings >= 1.2.0
 Requires:       s390-tools
 
+Supplements:    yast2-s390
+
 ExclusiveArch:  s390 s390x
 
 %description

--- a/package/yast2-cio.spec
+++ b/package/yast2-cio.spec
@@ -24,7 +24,7 @@
 ######################################################################
 
 Name:           yast2-cio
-Version:        4.2.1
+Version:        4.2.2
 Release:        0
 Summary:        YaST2 - IO Channel management
 Group:          System/YaST


### PR DESCRIPTION
## Trello

https://trello.com/c/ODOyd5Yh/


## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1158036

## Problem

This module is not installed by default in an S/390 installation, but it should be.

## Solution

Added a `Supplements: yast2-s390` to the .spec file so this module is also installed whenever the yast2-s390 module is installed (which is the default for S/390 installations because it's there in the base system pattern).

## Test

We agreed to leave testing to our S/390 experts.


## Related PR

https://github.com/yast/yast-reipl/pull/27