### PR TITLE
Fixed unit test failure in Tumbleweed (Ruby 3.1) (bsc#1198982)

### DIFF
--- a/package/yast2-cio.changes
+++ b/package/yast2-cio.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Apr 28 14:04:08 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed unit test failure in Tumbleweed (Ruby 3.1) (bsc#1198982)
+- 4.5.1
+
+-------------------------------------------------------------------
 Wed Apr 06 13:24:58 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 4.5.0 (bsc#1198109)

--- a/package/yast2-cio.spec
+++ b/package/yast2-cio.spec
@@ -24,7 +24,7 @@
 ######################################################################
 
 Name:           yast2-cio
-Version:        4.5.0
+Version:        4.5.1
 Release:        0
 Summary:        YaST2 - IO Channel management
 Group:          System/YaST

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -18,6 +18,8 @@
 
 $:.unshift(File.expand_path("../../src/lib", __FILE__))
 
+require "yast"
+
 LSCSS_OUTPUT = File.read(File.expand_path("../data/lscss.txt", __FILE__))
 
 # configure RSpec


### PR DESCRIPTION
## Problem

- Fixed unit test failure in Tumbleweed (Ruby 3.1):
```
undefined symbol: _Z10y2_requirePKc - /usr/lib64/ruby/vendor_ruby/3.1.0/x86_64-linux-gnu/yast/builtinx.so
``` 
- Example: https://github.com/yast/yast-cio/runs/6189959141?check_suite_focus=true#step:5:13

## Solution

- Simple adding `require "yast"` fixed the problem... :thinking: 

## Testing

- The GitHub Action is now green