### PR TITLE
Stop using File.exists? which no longer works in Ruby 3.2 (bsc#1206419)

### DIFF
--- a/manual_testing/bin/lscss
+++ b/manual_testing/bin/lscss
@@ -23,7 +23,7 @@ require "fileutils"
 orig_dir = File.expand_path("../../data", __FILE__)
 data_file = "#{orig_dir}/lscss.output"
 
-if !File.exists? data_file
+if !File.exist? data_file
   FileUtils.cp "#{orig_dir}/lscss.output.orig", data_file
 end
 

--- a/package/yast2-cio.changes
+++ b/package/yast2-cio.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Mar  6 17:18:57 UTC 2023 - Martin Vidner <mvidner@suse.com>
+
+- Stop using File.exists? which no longer works in Ruby 3.2
+  (bsc#1206419)
+- 4.6.1
+
+-------------------------------------------------------------------
 Fri Mar 03 14:44:07 UTC 2023 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 4.6.0 (bsc#1208913)

--- a/package/yast2-cio.spec
+++ b/package/yast2-cio.spec
@@ -24,7 +24,7 @@
 ######################################################################
 
 Name:           yast2-cio
-Version:        4.6.0
+Version:        4.6.1
 Release:        0
 Summary:        YaST2 - IO Channel management
 Group:          System/YaST


### PR DESCRIPTION
## Problem

Ruby 3.2 removed `File.exists?` which has been long deprecated in favor of `File.exist?`

Here it occurs only in a script used for local development on a non-s390, not part of the RPM.

- https://trello.com/c/jRe5bWVE
- https://bugzilla.suse.com/show_bug.cgi?id=1206419

## Solution

Fix the script.

~~No new package, the file is not part of RPM~~ Well a new package is easy enough, let's keep it regular.

## Testing

Manually: `./manual_testing/bin/lscss`

## Screenshots

N/A
